### PR TITLE
The REST API checks were not correctly implemented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-cloudwatch-settings",
-  "version": "1.2.0-rc1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-cloudwatch-settings",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-cloudwatch-settings",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "description": "A Serverless v1.x plugin that enables you to easily configure the CloudWatch settings for an API Gateway.",
   "main": "src/Plugin.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-gateway-cloudwatch-settings",
-  "version": "1.2.0-rc1",
+  "version": "1.2.0",
   "description": "A Serverless v1.x plugin that enables you to easily configure the CloudWatch settings for an API Gateway.",
   "main": "src/Plugin.js",
   "scripts": {

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -23,7 +23,9 @@ class Plugin {
   }
 
   interceptRestApiId() {
-    outputRestApiIdTo(this.serverless);
+    if (!this.cloudFormationContainsARestApi) {
+      outputRestApiIdTo(this.serverless);
+    }
   }
 
   updateApiStage() {

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -23,17 +23,17 @@ class Plugin {
   }
 
   interceptRestApiId() {
-    if (!this.cloudFormationContainsARestApi) {
+    if (this.cloudFormationContainsARestApi()) {
       outputRestApiIdTo(this.serverless);
     }
   }
 
   updateApiStage() {
-    if (!this.cloudFormationContainsARestApi) {
-      this.serverless.cli.log(`[${pluginName}] Not performing an update because no REST API was found.`);
-      return;
-    }
-    return callAws.toUpdateApiStage(this.serverless, this.apiStageSettings);
+    if (this.cloudFormationContainsARestApi()) {
+      return callAws.toUpdateApiStage(this.serverless, this.apiStageSettings);
+    } else {
+      this.serverless.cli.log(`[${pluginName}] Not performing an update because no REST API was found.`); 
+    }    
   }
 
   cloudFormationContainsARestApi() {


### PR DESCRIPTION
It only caused an issue in the case that the plugin is used when there is no REST API configured.